### PR TITLE
Preinstall option for workstations without typings installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spsave",
   "description": "Save files in SharePoint using node.js easily",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Sergei Sergeev <sergeev.srg@gmail.com>",
   "main": "./lib/src/index.js",
   "typings": "./lib/src/index",
@@ -14,6 +14,7 @@
     "dev": "gulp live-dev",
     "test-int": "gulp test-int",
     "test-perf": "gulp tsc && node lib/test/performance/index.js",
+    "preinstall": "npm list typings -g || npm install typings -g",
     "postinstall": "typings install"
   },
   "bugs": {


### PR DESCRIPTION
Hi,

This pull request adds `preinstall` option to scripts in package.json.
In the preinstall `typings` module global installation is checked and initiated if missed.

The reason for this is that there are some cases then on a workstation `typings` could be missed in global modules. As a reason, the module installation will be stopped.

When `spsave` is used as a 3rd party reference, all dependencies installation after spsave reference will be blocked on a machine without typings installed globally.

Sergei, could you please check possibility to add `"preinstall": "npm list typings -g || npm install typings -g"` or remove `"postinstall": "typings install"`. Sometimes prerequisites statement in a readme can be omitted and a newbie developer could face an error.