### PR TITLE
Update FileSaver.ts

### DIFF
--- a/src/core/FileSaver.ts
+++ b/src/core/FileSaver.ts
@@ -137,12 +137,12 @@ export class FileSaver {
         }
       })
       .catch((err: HTTPError) => {
-        if (err && (err.response.statusCode === 500 || err.response.statusCode === 409)) { /* save conflict or cobalt error */
+        if (err && (err.response?.statusCode === 500 || err.response?.statusCode === 409)) { /* save conflict or cobalt error */
           this.tryReUpload(err, requestDeferred, attempts);
           return;
         }
         /* folder doesn't exist, create and reupload */
-        if (err && err.response.statusCode === 404 && err.response.body && err.response.body.toString().indexOf(FileSaver.directoryNotFoundCode) !== -1) {
+        if (err && err.response?.statusCode === 404 && err.response?.body && err.response?.body.toString().indexOf(FileSaver.directoryNotFoundCode) !== -1) {
           this.foldersCreator.createFoldersHierarchy()
             .then(() => {
               this.saveFile(requestDeferred, attempts + 1);


### PR DESCRIPTION
Updated FileSaver according to #67.
'err.response' is not defined when SharePoint returns:

message:'<S:Fault>\n  <S:Code>\n    <S:Value>S:Sender</S:Value>\n    <S:Subcode>\n      <S:Value>wst:FailedAuthentication</S:Value>\n    </S:Subcode>\n  </S:Code>\n  <S:Reason>\n    <S:Text xml:lang="en-US">Authentication Failure</S:Text>\n  </S:Reason>\n  <S:Detail>\n    <psf:error xmlns:psf="http://schemas.microsoft.com/Passport/SoapServices/SOAPFault">\n      <psf:value>0x80048821</psf:value>\n      <psf:internalerror>\n        <psf:code>0x80048821</psf:code>\n        <psf:text>AADSTS50126: Error validating credentials due to invalid username or password.</psf:text>\n      </psf:internalerror>\n    </psf:error>\n  </S:Detail>\n</S:Fault>'

Caused by wrong credentials.